### PR TITLE
LPS-100750 Segmenting imageAlt and imageTitle on img attributes

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/FloatingToolbar.soy
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/FloatingToolbar.soy
@@ -17,6 +17,7 @@
 	]>}
 	{@param? _handlePanelButtonClick: any}
 	{@param? classes: string}
+	{@param? defaultSegmentsExperienceId: string}
 	{@param? fixSelectedPanel: bool}
 	{@param? selectedPanelId: string}
 	{@param? spritemap: string}
@@ -45,6 +46,7 @@
 		{if $selectedPanelId}
 			<div class="fragments-editor__floating-toolbar-panel" ref="panel">
 				{delcall com.liferay.layout.content.page.editor.web.FloatingToolbarPanel variant="$selectedPanelId"}
+					{param defaultSegmentsExperienceId: $defaultSegmentsExperienceId /}
 					{param item: $item /}
 					{param itemId: $itemId /}
 					{param itemType: $itemType /}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanel.soy
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanel.soy
@@ -5,9 +5,13 @@
  */
 {template .render}
 	{@param item: ?}
+	{@param? imageAlt: string}
+	{@param? imageTitle: string}
 	{@param? _handleAltTextInputChange: any}
 	{@param? _handleClearImageButtonClick: any}
 	{@param? _handleSelectImageButtonClick: any}
+	{@param? defaultSegmentsExperienceId: string}
+	{@param? segmentsExperienceId: string}
 
 	<div class="popover p-3">
 		<div class="floating-toolbar-spacing-panel">
@@ -27,7 +31,7 @@
 						id="floatingToolbarImagePropertiesPanelSelectImage"
 						readonly="readonly"
 						type="text"
-						value="{$item.editableValues.config ? $item.editableValues.config.imageTitle ?: $item.editableValues.config.imageSource ?: '' : ''}"
+						value="{$imageTitle}"
 					/>
 				</div>
 
@@ -58,7 +62,7 @@
 
 			{call .altText}
 				{param _handleAltTextInputChange: $_handleAltTextInputChange /}
-				{param item: $item /}
+				{param imageAlt: $imageAlt /}
 			{/call}
 		</div>
 	</div>
@@ -68,8 +72,8 @@
  * Alternative text Input
  */
 {template .altText}
-	{@param item: ?}
 	{@param? _handleAltTextInputChange: any}
+	{@param? imageAlt: string }
 
 	<div class="form-group">
 		<label for="floatingToolbarImagePropertiesPanelAltText">
@@ -77,8 +81,8 @@
 		</label>
 
 		{let $inputValue kind="text"}
-			{if $item.editableValues.config and $item.editableValues.config.alt}
-				{$item.editableValues.config.alt}
+			{if $imageAlt}
+				{$imageAlt}
 			{/if}
 		{/let}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanelDelegateTemplate.soy
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanelDelegateTemplate.soy
@@ -7,12 +7,14 @@
 	{@param item: ?}
 	{@param itemId: string}
 	{@param itemType: string}
+	{@param? defaultSegmentsExperienceId: string}
 	{@param? store: ?}
 
 	{call com.liferay.layout.content.page.editor.web.FloatingToolbarImagePropertiesPanel.render}
 		{param item: $item /}
 		{param itemId: $itemId /}
 		{param itemType: $itemType /}
+		{param defaultSegmentsExperienceId: $defaultSegmentsExperienceId /}
 		{param store: $store /}
 	{/call}
 {/deltemplate}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/reducers/fragments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/reducers/fragments.es.js
@@ -35,6 +35,7 @@ import {
 	getFragmentRowIndex
 } from '../utils/FragmentsEditorGetUtils.es';
 import {updatePageEditorLayoutData} from '../utils/FragmentsEditorFetchUtils.es';
+import {prefixSegmentsExperienceId} from '../utils/prefixSegmentsExperienceId.es';
 
 /**
  * Adds a fragment at the corresponding container in the layout
@@ -520,6 +521,11 @@ function updateFragmentEntryLinkConfigReducer(state, action) {
 			fragmentEntryLinkId
 		];
 
+		const {segmentsExperienceId} = nextState;
+		const prefixedEperienceId = prefixSegmentsExperienceId(
+			segmentsExperienceId
+		);
+
 		Object.entries(config).forEach(entry => {
 			const [key, value] = entry;
 
@@ -527,6 +533,7 @@ function updateFragmentEntryLinkConfigReducer(state, action) {
 				EDITABLE_FRAGMENT_ENTRY_PROCESSOR,
 				editableId,
 				'config',
+				prefixedEperienceId,
 				key
 			];
 


### PR DESCRIPTION
Don't merge this. It's just a PoC and it needs further development from the backend. ⚠️☢️🧨🔥
- [ ] Check how is this working with **mapped fragments**
- [ ] Check how this is working on **widget pages**
- [ ] Make that deleting an Experience or a Variant triggers a **clean up** of this values
- [ ] There are **other `config` values** that are potentially segmentable.